### PR TITLE
Add reset confirmation modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -1684,6 +1684,15 @@ const closeExerciseModal = () => {
     document.getElementById('exercise-modal').classList.add('hidden');
 };
 
+// --- Reset Confirmation Modal ---
+const openResetModal = () => {
+    document.getElementById('reset-modal').classList.remove('hidden');
+};
+
+const closeResetModal = () => {
+    document.getElementById('reset-modal').classList.add('hidden');
+};
+
 // --- PWA Install Prompt ---
 let deferredPrompt;
 const installButton = document.getElementById('install-button');

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
                     <button id="install-button" class="hidden text-sm text-lime-400 hover:text-lime-300 transition-colors underline">Install App</button>
                     <button onclick="openProgressModal()" class="text-sm text-gray-500 hover:text-lime-400 transition-colors underline clickable">View Analytics</button>
                     <button onclick="openNotificationSettings()" class="text-sm text-gray-500 hover:text-lime-400 transition-colors underline clickable">Notifications</button>
-                    <button onclick="resetProgram()" class="text-sm text-gray-500 hover:text-red-500 transition-colors underline clickable">Change Difficulty / Program</button>
+                    <button onclick="openResetModal()" class="text-sm text-gray-500 hover:text-red-500 transition-colors underline clickable">Change Difficulty / Program</button>
                 </div>
                 <p class="text-xs text-gray-600 mt-6">Made by Vinodh with <span class="text-lime-400">♥</span></p>
                 <div class="mt-4 flex flex-col sm:flex-row justify-center items-center space-y-2 sm:space-y-0 sm:space-x-4 text-xs text-gray-500 flex-wrap-mobile">
@@ -249,6 +249,18 @@
             <div class="mt-6 p-3 sm:p-4 bg-gray-800/50 rounded-lg">
                 <p class="text-xs text-gray-400 mb-2">📱 <strong>Mobile Tip:</strong></p>
                 <p class="text-xs text-gray-400">For best results, add HYBRID OPS to your home screen and enable notifications in your device settings.</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Reset Confirmation Modal -->
+    <div id="reset-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4 hidden scale-in">
+        <div class="modal-content bg-gray-900 border border-gray-700 rounded-lg max-w-md w-full p-4 sm:p-6 relative text-center">
+            <h2 class="text-xl sm:text-2xl font-bold text-red-400 mb-4 font-display uppercase tracking-wider text-glow">Reset Progress?</h2>
+            <p class="text-gray-400 mb-6">This will erase all progress. This action cannot be undone.</p>
+            <div class="flex justify-center space-x-4">
+                <button onclick="resetProgram(); closeResetModal();" class="bg-red-600 hover:bg-red-700 text-black px-4 py-2 rounded font-bold clickable">Proceed</button>
+                <button onclick="closeResetModal()" class="bg-gray-700 hover:bg-gray-600 text-gray-300 px-4 py-2 rounded font-bold clickable">Cancel</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add reset confirmation modal with warning and proceed/cancel options
- add openResetModal and closeResetModal helpers and wire footer button to trigger modal

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8fc4ec4c8832fa2b1009fa82de535