### PR TITLE
Handle deferred PWA install prompt

### DIFF
--- a/app.js
+++ b/app.js
@@ -1707,15 +1707,20 @@ window.addEventListener('beforeinstallprompt', (e) => {
 });
 
 installButton.addEventListener('click', async () => {
-  // Hide the app provided install promotion
-  installButton.classList.add('hidden');
   // Show the install prompt
   deferredPrompt.prompt();
   // Wait for the user to respond to the prompt
   const { outcome } = await deferredPrompt.userChoice;
   console.log(`User response to the install prompt: ${outcome}`);
+  // Hide the app provided install promotion
+  installButton.classList.add('hidden');
   // We've used the prompt, and can't use it again, throw it away
   deferredPrompt = null;
+});
+
+// Hide the install button if the app is installed
+window.addEventListener('appinstalled', () => {
+  installButton.classList.add('hidden');
 });
 
 // Initialize the app when the page loads


### PR DESCRIPTION
## Summary
- Display install button after `beforeinstallprompt` fires and store event
- Prompt user for installation on button click and hide button afterward
- Hide install button once the app is installed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9086f23fc832fa4faa7d42bf9c161