### PR TITLE
feat: add iOS install prompt

### DIFF
--- a/app.js
+++ b/app.js
@@ -1696,6 +1696,8 @@ const closeResetModal = () => {
 // --- PWA Install Prompt ---
 let deferredPrompt;
 const installButton = document.getElementById('install-button');
+const iosPrompt = document.getElementById('ios-pwa-prompt');
+const iosPromptDismiss = document.getElementById('ios-pwa-dismiss');
 
 window.addEventListener('beforeinstallprompt', (e) => {
   // Prevent the mini-infobar from appearing on mobile
@@ -1723,5 +1725,29 @@ window.addEventListener('appinstalled', () => {
   installButton.classList.add('hidden');
 });
 
-// Initialize the app when the page loads
-document.addEventListener('DOMContentLoaded', initializeApp);
+function checkIosInstallPrompt() {
+  const ua = window.navigator.userAgent.toLowerCase();
+  const isIOS = /iphone|ipad|ipod/.test(ua);
+  const isStandalone = window.navigator.standalone === true;
+  const isSafari = isIOS && /safari/.test(ua) && !/crios|fxios|edgios/.test(ua);
+  const dismissed = localStorage.getItem('iosPwaPromptDismissed');
+
+  if (isIOS && isSafari && !isStandalone && !dismissed) {
+    iosPrompt.classList.remove('hidden');
+  }
+}
+
+function dismissIosInstallPrompt() {
+  iosPrompt.classList.add('hidden');
+  localStorage.setItem('iosPwaPromptDismissed', 'true');
+}
+
+if (iosPromptDismiss) {
+  iosPromptDismiss.addEventListener('click', dismissIosInstallPrompt);
+}
+
+// Initialize the app and check iOS prompt when the page loads
+document.addEventListener('DOMContentLoaded', () => {
+  initializeApp();
+  checkIosInstallPrompt();
+});

--- a/index.html
+++ b/index.html
@@ -265,6 +265,12 @@
         </div>
     </div>
 
+    <!-- iOS Install Prompt -->
+    <div id="ios-pwa-prompt" class="fixed bottom-4 left-1/2 -translate-x-1/2 transform bg-gray-900 border border-lime-500 text-gray-200 p-4 rounded-lg shadow-lg text-center hidden z-50">
+        <p class="text-sm mb-2">Tap <span class="font-bold">Share</span> → <span class="font-bold">Add to Home Screen</span></p>
+        <button id="ios-pwa-dismiss" class="text-xs text-lime-400 hover:text-lime-300 underline">Dismiss</button>
+    </div>
+
     <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- detect iOS Safari and show an Add to Home Screen prompt
- allow users to dismiss the prompt permanently via localStorage
- ensure banner only shows on iOS Safari and hides in standalone mode

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b909f17018832fbb4af693f524b8fc