### PR TITLE
style: enhance bottom nav with glow icons

### DIFF
--- a/app.js
+++ b/app.js
@@ -1928,6 +1928,8 @@ function switchView(viewId) {
     tab.classList.toggle('active', isActive);
     tab.classList.toggle('text-lime-400', isActive);
     tab.classList.toggle('text-gray-400', !isActive);
+    tab.classList.toggle('font-display', isActive);
+    tab.classList.toggle('font-bold', isActive);
     if (isActive) {
       tab.setAttribute('aria-current', 'page');
     } else {

--- a/icons/analytics.svg
+++ b/icons/analytics.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <defs>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="2" result="coloredBlur" />
+      <feMerge>
+        <feMergeNode in="coloredBlur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <g fill="#A3E635" filter="url(#glow)">
+    <rect x="3" y="10" width="4" height="8" rx="1" />
+    <rect x="10" y="6" width="4" height="12" rx="1" />
+    <rect x="17" y="2" width="4" height="16" rx="1" />
+  </g>
+</svg>

--- a/icons/home.svg
+++ b/icons/home.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <defs>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="2" result="coloredBlur" />
+      <feMerge>
+        <feMergeNode in="coloredBlur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <path d="M3 9.5L12 3l9 6.5V20a1 1 0 0 1-1 1h-5v-6H9v6H4a1 1 0 0 1-1-1V9.5z" fill="#A3E635" filter="url(#glow)"/>
+</svg>

--- a/icons/settings.svg
+++ b/icons/settings.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <defs>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="2" result="coloredBlur" />
+      <feMerge>
+        <feMergeNode in="coloredBlur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <g filter="url(#glow)" stroke="#A3E635" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="3" fill="#A3E635" stroke="none" />
+    <path d="M12 2v4M12 18v4M2 12h4M18 12h4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -297,17 +297,17 @@
         <p class="text-gray-400">Settings content coming soon.</p>
     </section>
 
-    <nav class="fixed bottom-0 left-0 w-full bg-gray-900 border-t border-gray-700 flex justify-around py-2 text-sm">
-        <button id="tab-home" data-view="home" onclick="switchView('home')" class="flex flex-col items-center text-gray-400" aria-label="Home">
-            <span aria-hidden="true">🏠</span>
+    <nav class="fixed bottom-0 w-full flex justify-around py-2 bg-black/80 border-t border-gray-700 text-gray-400">
+        <button id="tab-home" data-view="home" onclick="switchView('home')" class="flex flex-col items-center text-gray-400 hover:text-lime-400" aria-label="Home">
+            <img src="icons/home.svg" alt="" class="w-6 h-6 nav-icon" aria-hidden="true" />
             <span class="text-xs">Home</span>
         </button>
-        <button id="tab-analytics" data-view="analytics" onclick="switchView('analytics')" class="flex flex-col items-center text-gray-400" aria-label="Analytics">
-            <span aria-hidden="true">📊</span>
+        <button id="tab-analytics" data-view="analytics" onclick="switchView('analytics')" class="flex flex-col items-center text-gray-400 hover:text-lime-400" aria-label="Analytics">
+            <img src="icons/analytics.svg" alt="" class="w-6 h-6 nav-icon" aria-hidden="true" />
             <span class="text-xs">Analytics</span>
         </button>
-        <button id="tab-settings" data-view="settings" onclick="switchView('settings')" class="flex flex-col items-center text-gray-400" aria-label="Settings">
-            <span aria-hidden="true">⚙️</span>
+        <button id="tab-settings" data-view="settings" onclick="switchView('settings')" class="flex flex-col items-center text-gray-400 hover:text-lime-400" aria-label="Settings">
+            <img src="icons/settings.svg" alt="" class="w-6 h-6 nav-icon" aria-hidden="true" />
             <span class="text-xs">Settings</span>
         </button>
     </nav>

--- a/styles.css
+++ b/styles.css
@@ -343,3 +343,7 @@ body {
     left: 0;
     color: #A3E635;
 }
+
+.nav-icon {
+    filter: drop-shadow(0 0 4px #A3E635);
+}


### PR DESCRIPTION
## Summary
- Restyle bottom navigation with dark translucent background and muted gray text
- Swap emoji tabs for custom lime SVG icons and add icon glow styling
- Update view switcher to toggle bold display font on active tab

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9168b30cc832f98d3e98e7e905fb4