### PR TITLE
Remove replay walkthrough option

### DIFF
--- a/app.js
+++ b/app.js
@@ -1757,7 +1757,6 @@ let onboardingStep = 0;
 let onboardingGoal = null;
 let onboardingDifficulty = null;
 let onboardingNotifications = null;
-let onboardingReplay = false;
 
 function renderOnboardingGoal() {
   return `
@@ -1870,16 +1869,13 @@ function showOnboardingStep() {
 function finishOnboarding() {
   onboardingModal.classList.add('hidden');
   localStorage.setItem('hasSeenOnboarding','true');
-  if (!onboardingReplay) {
-    if (onboardingGoal) localStorage.setItem('hybridGoal', onboardingGoal);
-    if (onboardingDifficulty) localStorage.setItem('hybridDifficulty', onboardingDifficulty);
-    initializeApp();
-    checkIosInstallPrompt();
-  }
+  if (onboardingGoal) localStorage.setItem('hybridGoal', onboardingGoal);
+  if (onboardingDifficulty) localStorage.setItem('hybridDifficulty', onboardingDifficulty);
+  initializeApp();
+  checkIosInstallPrompt();
 }
 
-function startOnboarding(replay = false) {
-  onboardingReplay = replay;
+function startOnboarding() {
   onboardingStep = 0;
   onboardingGoal = null;
   onboardingDifficulty = null;
@@ -1891,7 +1887,7 @@ function startOnboarding(replay = false) {
 onboardingNext.addEventListener('click', () => {
   if (onboardingStep === 0 && !onboardingGoal) return;
   if (onboardingStep === 1 && !onboardingDifficulty) return;
-  if (onboardingStep === 1 && !onboardingReplay) {
+  if (onboardingStep === 1) {
     if (onboardingGoal) localStorage.setItem('hybridGoal', onboardingGoal);
     if (onboardingDifficulty) localStorage.setItem('hybridDifficulty', onboardingDifficulty);
     initializeApp();

--- a/index.html
+++ b/index.html
@@ -137,7 +137,6 @@
                     <button id="install-button" class="hidden text-sm text-lime-400 hover:text-lime-300 transition-colors underline">Install App</button>
                     <button onclick="openProgressModal()" class="text-sm text-gray-500 hover:text-lime-400 transition-colors underline clickable">View Analytics</button>
                     <button onclick="openNotificationSettings()" class="text-sm text-gray-500 hover:text-lime-400 transition-colors underline clickable">Notifications</button>
-                    <button onclick="startOnboarding(true)" class="text-sm text-gray-500 hover:text-lime-400 transition-colors underline clickable">Replay Walkthrough</button>
                     <button onclick="openResetModal()" class="text-sm text-gray-500 hover:text-red-500 transition-colors underline clickable">Change Difficulty / Program</button>
                 </div>
                 <p class="text-xs text-gray-600 mt-6">Made by Vinodh with <span class="text-lime-400">♥</span></p>


### PR DESCRIPTION
## Summary
- Remove Replay Walkthrough button from the footer.
- Simplify onboarding logic by removing replay-specific code.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b91877fc78832f91274a9a554daa49