### PR TITLE
Move footer controls into dedicated settings view

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,8 +136,6 @@
                 <div class="mt-4 flex flex-col sm:flex-row justify-center items-center space-y-4 sm:space-y-0 sm:space-x-4 lg:space-x-6">
                     <button id="install-button" class="hidden text-sm text-lime-400 hover:text-lime-300 transition-colors underline">Install App</button>
                     <button onclick="openProgressModal()" class="text-sm text-gray-500 hover:text-lime-400 transition-colors underline clickable">View Analytics</button>
-                    <button onclick="openNotificationSettings()" class="text-sm text-gray-500 hover:text-lime-400 transition-colors underline clickable">Notifications</button>
-                    <button onclick="openResetModal()" class="text-sm text-gray-500 hover:text-red-500 transition-colors underline clickable">Change Difficulty / Program</button>
                 </div>
                 <p class="text-xs text-gray-600 mt-6">Made by Vinodh with <span class="text-lime-400">♥</span></p>
                 <div class="mt-4 flex flex-col sm:flex-row justify-center items-center space-y-2 sm:space-y-0 sm:space-x-4 text-xs text-gray-500 flex-wrap-mobile">
@@ -293,7 +291,10 @@
 
     <section id="settings" class="hidden container mx-auto max-w-4xl p-4 sm:p-6">
         <h2 class="text-xl font-display text-lime-400 mb-4">Settings</h2>
-        <p class="text-gray-400">Settings content coming soon.</p>
+        <div class="space-y-4 max-w-sm mx-auto">
+            <button onclick="openNotificationSettings()" class="w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Notifications</button>
+            <button onclick="resetProgram()" class="w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Change Difficulty / Program</button>
+        </div>
     </section>
 
     <nav class="fixed bottom-0 w-full flex justify-around py-2 bg-black/80 border-t border-gray-700 text-gray-400">


### PR DESCRIPTION
## Summary
- Remove footer links for notifications and program reset to simplify main view
- Add Settings section with buttons for Notifications and Change Difficulty / Program
- Hook Settings navigation tab to display configuration view and hide main program

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b91ba1157c832f8fef55a0d68fef05