### PR TITLE
Hide bottom nav until program loads

### DIFF
--- a/app.js
+++ b/app.js
@@ -553,6 +553,7 @@ const programContainer = document.getElementById('program-container');
 const difficultySelectionScreen = document.getElementById('difficulty-selection');
 const appContent = document.getElementById('app-content');
 const goalSelectionScreen = document.getElementById('goal-selection');
+const bottomNav = document.getElementById('bottom-nav');
 let progressChart = null;
 
 let completionStatus = {};
@@ -1214,6 +1215,7 @@ const renderProgram = () => {
             startWorkoutTimer(dayId);
         }
     });
+    bottomNav.classList.remove('hidden');
 };
 
 const showWelcomeMessage = () => {
@@ -1259,6 +1261,7 @@ const selectGoal = (goal) => {
 };
 
 const initializeApp = () => {
+    bottomNav.classList.add('hidden');
     const savedGoal = localStorage.getItem('hybridGoal');
     const savedDifficulty = localStorage.getItem('hybridDifficulty');
     

--- a/index.html
+++ b/index.html
@@ -297,7 +297,7 @@
         </div>
     </section>
 
-    <nav class="fixed bottom-0 w-full flex justify-around py-2 bg-black/80 border-t border-gray-700 text-gray-400">
+    <nav id="bottom-nav" class="hidden fixed bottom-0 w-full flex justify-around py-2 bg-black/80 border-t border-gray-700 text-gray-400">
         <button id="tab-home" data-view="home" onclick="switchView('home')" class="flex flex-col items-center text-gray-400 hover:text-lime-400" aria-label="Home">
             <img src="icons/home.svg" alt="" class="w-6 h-6 nav-icon" aria-hidden="true" />
             <span class="text-xs">Home</span>


### PR DESCRIPTION
## Summary
- Wrap bottom navigation in a `nav` with `id="bottom-nav"` and a `hidden` class so it's hidden until needed.
- Add bottom-nav DOM reference and toggle visibility: hide on app init and reveal once the workout program renders.
- Keep the navigation hidden on welcome and selection screens, showing it only after the program loads.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b91d649148832fb9ea510f1ba0ba8b