### PR TITLE
Remove glow effects from navigation icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,15 +299,15 @@
 
     <nav class="fixed bottom-0 w-full flex justify-around py-2 bg-black/80 border-t border-gray-700 text-gray-400">
         <button id="tab-home" data-view="home" onclick="switchView('home')" class="flex flex-col items-center text-gray-400 hover:text-lime-400" aria-label="Home">
-            <img src="icons/home.svg" alt="" class="w-6 h-6 nav-icon" aria-hidden="true" />
+            <img src="icons/home.svg" alt="" class="w-6 h-6" aria-hidden="true" />
             <span class="text-xs">Home</span>
         </button>
         <button id="tab-analytics" data-view="analytics" onclick="switchView('analytics')" class="flex flex-col items-center text-gray-400 hover:text-lime-400" aria-label="Analytics">
-            <img src="icons/analytics.svg" alt="" class="w-6 h-6 nav-icon" aria-hidden="true" />
+            <img src="icons/analytics.svg" alt="" class="w-6 h-6" aria-hidden="true" />
             <span class="text-xs">Analytics</span>
         </button>
         <button id="tab-settings" data-view="settings" onclick="switchView('settings')" class="flex flex-col items-center text-gray-400 hover:text-lime-400" aria-label="Settings">
-            <img src="icons/settings.svg" alt="" class="w-6 h-6 nav-icon" aria-hidden="true" />
+            <img src="icons/settings.svg" alt="" class="w-6 h-6" aria-hidden="true" />
             <span class="text-xs">Settings</span>
         </button>
     </nav>

--- a/styles.css
+++ b/styles.css
@@ -345,5 +345,5 @@ body {
 }
 
 .nav-icon {
-    filter: drop-shadow(0 0 4px #A3E635);
+    filter: none;
 }


### PR DESCRIPTION
## Summary
- strip glow classes from nav bar icons for clean flat rendering
- drop glow filter from nav-icon CSS class

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b91df76b04832f9a52478c926b7fd9