### PR TITLE
Remove redundant analytics button

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,6 @@
                 <p class="font-display tracking-widest text-lime-400 text-glow">Stay Hybrid. Stay Relentless.</p>
                 <div class="mt-4 flex flex-col sm:flex-row justify-center items-center space-y-4 sm:space-y-0 sm:space-x-4 lg:space-x-6">
                     <button id="install-button" class="hidden text-sm text-lime-400 hover:text-lime-300 transition-colors underline">Install App</button>
-                    <button onclick="openProgressModal()" class="text-sm text-gray-500 hover:text-lime-400 transition-colors underline clickable">View Analytics</button>
                 </div>
                 <p class="text-xs text-gray-600 mt-6">Made by Vinodh with <span class="text-lime-400">♥</span></p>
                 <div class="mt-4 flex flex-col sm:flex-row justify-center items-center space-y-2 sm:space-y-0 sm:space-x-4 text-xs text-gray-500 flex-wrap-mobile">
@@ -302,7 +301,7 @@
             <img src="icons/home.svg" alt="" class="w-6 h-6" aria-hidden="true" />
             <span class="text-xs">Home</span>
         </button>
-        <button id="tab-analytics" data-view="analytics" onclick="switchView('analytics')" class="flex flex-col items-center text-gray-400 hover:text-lime-400" aria-label="Analytics">
+        <button id="tab-analytics" data-view="analytics" onclick="switchView('analytics'); openProgressModal();" class="flex flex-col items-center text-gray-400 hover:text-lime-400" aria-label="Analytics">
             <img src="icons/analytics.svg" alt="" class="w-6 h-6" aria-hidden="true" />
             <span class="text-xs">Analytics</span>
         </button>


### PR DESCRIPTION
## Summary
- remove footer View Analytics button
- ensure navigation Analytics tab opens progress modal for performance data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9218a07f8832f9787bf8de51874e6