### PR TITLE
Move policy links into settings panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,13 +137,7 @@
                     <button id="install-button" class="hidden text-sm text-lime-400 hover:text-lime-300 transition-colors underline">Install App</button>
                 </div>
                 <p class="text-xs text-gray-600 mt-6">Made by Vinodh with <span class="text-lime-400">♥</span></p>
-                <div class="mt-4 flex flex-col sm:flex-row justify-center items-center space-y-2 sm:space-y-0 sm:space-x-4 text-xs text-gray-500 flex-wrap-mobile">
-                    <a href="privacy.html" class="hover:underline hover:text-gray-400 transition-colors">Privacy Policy</a>
-                    <span class="text-gray-600 hidden sm:inline">|</span>
-                    <a href="terms.html" class="hover:underline hover:text-gray-400 transition-colors">Terms of Service</a>
-                    <span class="text-gray-600 hidden sm:inline">|</span>
-                    <a href="contact.html" class="hover:underline hover:text-gray-400 transition-colors">Contact</a>
-                </div>
+                
             </footer>
     </div>
     </div>
@@ -293,6 +287,9 @@
         <div class="space-y-4 max-w-sm mx-auto">
             <button onclick="openNotificationSettings()" class="w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Notifications</button>
             <button onclick="resetProgram()" class="w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Change Difficulty / Program</button>
+            <a href="privacy.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Privacy Policy</a>
+            <a href="terms.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Terms of Service</a>
+            <a href="contact.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Contact</a>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- remove privacy, terms, and contact links from footer
- add Privacy Policy, Terms of Service, and Contact links under Settings
- keep settings reachable via existing navigation bar

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b923f1a654832fb611b30fe41ff32a