### PR TITLE
Add setup onboarding screen with install and notification options

### DIFF
--- a/app.js
+++ b/app.js
@@ -587,7 +587,11 @@ const loadData = () => {
 const selectDifficulty = (level) => {
     localStorage.setItem('hybridDifficulty', level);
     currentDifficulty = level;
-    initializeApp();
+    difficultySelectionScreen.classList.add('hidden');
+    switchView('setup-screen');
+    if (deferredPrompt) {
+        installButton.classList.remove('hidden');
+    }
 };
 
 const selectWeightUnit = (unit) => {
@@ -1648,6 +1652,7 @@ const closeResetModal = () => {
 // --- PWA Install Prompt ---
 let deferredPrompt;
 const installButton = document.getElementById('install-button');
+const continueButton = document.getElementById('continue-button');
 const iosPrompt = document.getElementById('ios-pwa-prompt');
 const iosPromptDismiss = document.getElementById('ios-pwa-dismiss');
 
@@ -1675,6 +1680,15 @@ installButton.addEventListener('click', async () => {
 // Hide the install button if the app is installed
 window.addEventListener('appinstalled', () => {
   installButton.classList.add('hidden');
+});
+
+continueButton.addEventListener('click', () => {
+  const settings = getNotificationSettings();
+  saveNotificationSettings(settings);
+  document.getElementById('setup-screen').classList.add('hidden');
+  initializeApp();
+  switchView('home');
+  bottomNav.classList.remove('hidden');
 });
 
 function checkIosInstallPrompt() {

--- a/index.html
+++ b/index.html
@@ -24,6 +24,19 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body class="text-gray-300 antialiased">
+    <section id="setup-screen" class="hidden text-center flex flex-col justify-center min-h-[85vh] container mx-auto max-w-4xl p-4 sm:p-6 fade-in">
+        <div class="space-y-4 max-w-sm mx-auto">
+            <button onclick="toggleNotifications()" class="w-full p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">
+                Enable Notifications
+            </button>
+            <button id="install-button" class="hidden w-full p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">
+                Install App
+            </button>
+            <button id="continue-button" class="w-full p-4 bg-lime-500 hover:bg-lime-600 text-black font-bold rounded-lg">
+                Continue
+            </button>
+        </div>
+    </section>
     <section id="home">
     <div class="container mx-auto max-w-4xl p-4 sm:p-6">
         
@@ -133,11 +146,8 @@
 
             <footer class="text-center mt-12">
                 <p class="font-display tracking-widest text-lime-400 text-glow">Stay Hybrid. Stay Relentless.</p>
-                <div class="mt-4 flex flex-col sm:flex-row justify-center items-center space-y-4 sm:space-y-0 sm:space-x-4 lg:space-x-6">
-                    <button id="install-button" class="hidden text-sm text-lime-400 hover:text-lime-300 transition-colors underline">Install App</button>
-                </div>
                 <p class="text-xs text-gray-600 mt-6">Made by Vinodh with <span class="text-lime-400">♥</span></p>
-                
+
             </footer>
     </div>
     </div>


### PR DESCRIPTION
## Summary
- Introduce a dedicated setup screen that lets users enable notifications, install the PWA, or continue to the program.
- Defer app initialization until after difficulty selection and setup completion.
- Add Continue button logic to persist notification choices, initialize the app, and reveal navigation.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9270a870c832fb4eecadd807e74ab