### PR TITLE
Add back link to privacy policy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -23,9 +23,32 @@
     a:hover {
       text-decoration: underline;
     }
+    .back-link {
+      display: inline-block;
+      margin-bottom: 2rem;
+      padding: 0.5rem 1rem;
+      background: transparent;
+      border: 2px solid #A3E635;
+      color: #A3E635;
+      text-decoration: none;
+      border-radius: 0.5rem;
+      transition: all 0.3s ease;
+      font-family: 'Changa', sans-serif;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+    }
+    .back-link:hover {
+      background: #A3E635;
+      color: #000000;
+      text-decoration: none;
+    }
   </style>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Changa:wght@600;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
 </head>
 <body>
+  <a href="index.html" class="back-link">← Back to HYBRID OPS</a>
   <h1>Privacy Policy</h1>
   <p>Effective Date: 2025-09-03</p>
 


### PR DESCRIPTION
## Summary
- Style and add a back navigation link to `privacy.html` so users can easily return to the main app.
- Include Google Fonts import to match appearance with other pages.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b928ee5c34832fb392ca92b880c307