### PR TITLE
Fix progress modal initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -1384,7 +1384,7 @@ function updateReminderTime(time) {
 // --- Chart Functions ---
 const openProgressModal = () => {
     document.getElementById('progress-modal').classList.remove('hidden');
-    populateExerciseChart();
+    populateExerciseSelect();
 };
 
 const closeProgressModal = () => {


### PR DESCRIPTION
## Summary
- Call `populateExerciseSelect()` when opening the progress modal to load exercise options and chart data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `timeout 3 npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68b92a648588832fb3a7aea62d02fe23