### PR TITLE
Refine notification settings management

### DIFF
--- a/app.js
+++ b/app.js
@@ -1295,6 +1295,38 @@ const initializeApp = () => {
 };
 
 // Notification Settings Functions
+function getNotificationSettings() {
+    return JSON.parse(localStorage.getItem('notificationSettings')) || {
+        enabled: false,
+        workoutReminders: true,
+        completionCelebrations: true,
+        weeklyProgress: true,
+        reminderTime: '09:00'
+    };
+}
+
+function saveNotificationSettings(settings) {
+    localStorage.setItem('notificationSettings', JSON.stringify(settings));
+}
+
+function requestNotificationPermission() {
+    return new Promise(resolve => {
+        if (!('Notification' in window)) {
+            resolve(false);
+            return;
+        }
+        if (Notification.permission === 'granted') {
+            resolve(true);
+        } else if (Notification.permission !== 'denied') {
+            Notification.requestPermission().then(permission => {
+                resolve(permission === 'granted');
+            });
+        } else {
+            resolve(false);
+        }
+    });
+}
+
 function openNotificationSettings() {
     document.getElementById('notification-modal').classList.remove('hidden');
     updateNotificationSettingsDisplay();
@@ -1378,6 +1410,7 @@ function updateReminderTime(time) {
     const settings = getNotificationSettings();
     settings.reminderTime = time;
     saveNotificationSettings(settings);
+    updateNotificationSettingsDisplay();
 }
 
 


### PR DESCRIPTION
## Summary
- Centralize notification settings handling with `getNotificationSettings`, `saveNotificationSettings`, and permission helper
- Ensure notification modal reflects stored preferences via `updateNotificationSettingsDisplay`
- Use unified notification settings in toggle handlers and reminder time updates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b92bd312b0832f9634659ab5075d26