### PR TITLE
Defer notification permission until after app init

### DIFF
--- a/app.js
+++ b/app.js
@@ -1331,6 +1331,16 @@ function requestNotificationPermission() {
     });
 }
 
+function triggerNotificationPermission() {
+    if (localStorage.getItem('notificationsEnabled') === 'true') {
+        requestNotificationPermission().then(granted => {
+            if (!granted) {
+                localStorage.setItem('notificationsEnabled', 'false');
+            }
+        });
+    }
+}
+
 function openNotificationSettings() {
     document.getElementById('notification-modal').classList.remove('hidden');
     updateNotificationSettingsDisplay();
@@ -1721,6 +1731,7 @@ continueButton.addEventListener('click', () => {
   document.getElementById('setup-screen').classList.add('hidden');
   initializeApp();
   switchView('home');
+  triggerNotificationPermission();
   bottomNav.classList.remove('hidden');
 });
 
@@ -1798,12 +1809,8 @@ function showOnboardingStep() {
         btn.classList.remove('bg-gray-700','text-gray-300');
         btn.classList.add('bg-lime-500','text-black');
         onboardingNext.disabled = false;
-        if (onboardingNotifications && 'Notification' in window) {
-          Notification.requestPermission().then(permission => {
-            if (permission === 'granted') {
-              localStorage.setItem('notificationsEnabled','true');
-            }
-          });
+        if (onboardingNotifications) {
+          localStorage.setItem('notificationsEnabled','true');
         } else {
           localStorage.setItem('notificationsEnabled','false');
         }
@@ -1824,6 +1831,8 @@ function finishOnboarding() {
   onboardingModal.classList.add('hidden');
   localStorage.setItem('hasSeenOnboarding','true');
   initializeApp();
+  switchView('home');
+  triggerNotificationPermission();
   checkIosInstallPrompt();
 }
 
@@ -1887,4 +1896,5 @@ document.addEventListener('DOMContentLoaded', () => {
     startOnboarding();
   }
   switchView('home');
+  triggerNotificationPermission();
 });


### PR DESCRIPTION
## Summary
- Store notification preference during onboarding without immediately requesting browser permission
- Request notification permission only after app initialization and home view activation via `triggerNotificationPermission`
- Trigger permission check on onboarding completion, setup continuation, and initial load

## Testing
- `npm test` *(fails: command not found)*
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99ff732a4832f8a79daf8d26cd1a0