### PR TITLE
Defer PWA install prompts until after onboarding

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,9 +29,6 @@
             <button onclick="toggleNotifications()" class="w-full p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">
                 Enable Notifications
             </button>
-            <button id="install-button" class="hidden w-full p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">
-                Install App
-            </button>
             <button id="continue-button" class="w-full p-4 bg-lime-500 hover:bg-lime-600 text-black font-bold rounded-lg">
                 Continue
             </button>
@@ -270,12 +267,9 @@
     <div id="onboarding-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4 hidden z-50">
         <div class="modal-content bg-gray-900 border border-gray-700 rounded-lg max-w-md w-full p-6 relative" role="dialog" aria-modal="true">
             <div id="onboarding-content"></div>
-            <div class="flex justify-between mt-6">
-                <button id="onboarding-back" class="px-4 py-2 bg-gray-700 text-gray-300 rounded disabled:opacity-50">Back</button>
-                <div class="space-x-2">
-                    <button id="onboarding-skip" class="text-sm text-gray-400 hover:text-lime-400 underline">Skip</button>
-                    <button id="onboarding-next" class="px-4 py-2 bg-lime-500 text-black font-bold rounded disabled:opacity-50">Next</button>
-                </div>
+            <div class="mt-6 flex justify-end space-x-2">
+                <button id="onboarding-skip" class="text-sm text-gray-400 hover:text-lime-400 underline">Skip</button>
+                <button id="onboarding-next" class="px-4 py-2 bg-lime-500 text-black font-bold rounded disabled:opacity-50">Finish</button>
             </div>
         </div>
     </div>
@@ -302,6 +296,10 @@
             <a href="contact.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Contact</a>
         </div>
     </section>
+
+    <button id="install-button" class="hidden fixed bottom-20 left-1/2 transform -translate-x-1/2 p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable z-40">
+        Install App
+    </button>
 
     <nav id="bottom-nav" class="hidden fixed bottom-0 w-full flex justify-around py-2 bg-black/80 border-t border-gray-700 text-gray-400">
         <button id="tab-home" data-view="home" onclick="switchView('home')" class="flex flex-col items-center text-gray-400 hover:text-lime-400" aria-label="Home">


### PR DESCRIPTION
## Summary
- remove onboarding install step and streamline walkthrough to notification setup only
- show install button and iOS install prompt only after home view is active
- move install button outside setup flow and hide until main program screen

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b99ffc392c832f94d93da8095a6ff7