### PR TITLE
Bypass setup screen and remove install handlers

### DIFF
--- a/app.js
+++ b/app.js
@@ -588,10 +588,12 @@ const selectDifficulty = (level) => {
     localStorage.setItem('hybridDifficulty', level);
     currentDifficulty = level;
     difficultySelectionScreen.classList.add('hidden');
-    switchView('setup-screen');
-    if (deferredPrompt) {
-        installButton.classList.remove('hidden');
-    }
+    const settings = getNotificationSettings();
+    saveNotificationSettings(settings);
+    initializeApp();
+    switchView('home');
+    triggerNotificationPermission();
+    bottomNav.classList.remove('hidden');
 };
 
 const selectWeightUnit = (unit) => {
@@ -1694,46 +1696,8 @@ const closeResetModal = () => {
 
 // --- PWA Install Prompt ---
 let deferredPrompt;
-const installButton = document.getElementById('install-button');
-const continueButton = document.getElementById('continue-button');
 const iosPrompt = document.getElementById('ios-pwa-prompt');
 const iosPromptDismiss = document.getElementById('ios-pwa-dismiss');
-
-window.addEventListener('beforeinstallprompt', (e) => {
-  // Prevent the mini-infobar from appearing on mobile
-  e.preventDefault();
-  // Stash the event so it can be triggered later.
-  deferredPrompt = e;
-  // Update UI to notify the user they can install the PWA
-  installButton.classList.remove('hidden');
-});
-
-installButton.addEventListener('click', async () => {
-  // Show the install prompt
-  deferredPrompt.prompt();
-  // Wait for the user to respond to the prompt
-  const { outcome } = await deferredPrompt.userChoice;
-  console.log(`User response to the install prompt: ${outcome}`);
-  // Hide the app provided install promotion
-  installButton.classList.add('hidden');
-  // We've used the prompt, and can't use it again, throw it away
-  deferredPrompt = null;
-});
-
-// Hide the install button if the app is installed
-window.addEventListener('appinstalled', () => {
-  installButton.classList.add('hidden');
-});
-
-continueButton.addEventListener('click', () => {
-  const settings = getNotificationSettings();
-  saveNotificationSettings(settings);
-  document.getElementById('setup-screen').classList.add('hidden');
-  initializeApp();
-  switchView('home');
-  triggerNotificationPermission();
-  bottomNav.classList.remove('hidden');
-});
 
 function checkIosInstallPrompt() {
   const ua = window.navigator.userAgent.toLowerCase();
@@ -1816,11 +1780,6 @@ function showOnboardingStep() {
         }
       });
     });
-  } else if (onboardingStep === 1) {
-    const installBtn = onboardingModal.querySelector('#onboarding-install');
-    if (installBtn) {
-      installBtn.addEventListener('click', () => installButton.click());
-    }
   }
 
   const focusable = onboardingModal.querySelector('button');

--- a/index.html
+++ b/index.html
@@ -24,19 +24,6 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body class="text-gray-300 antialiased">
-    <section id="setup-screen" class="hidden text-center flex flex-col justify-center min-h-[85vh] container mx-auto max-w-4xl p-4 sm:p-6 fade-in">
-        <div class="space-y-4 max-w-sm mx-auto">
-            <button onclick="toggleNotifications()" class="w-full p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">
-                Enable Notifications
-            </button>
-            <button id="install-button" class="hidden w-full p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">
-                Install App
-            </button>
-            <button id="continue-button" class="w-full p-4 bg-lime-500 hover:bg-lime-600 text-black font-bold rounded-lg">
-                Continue
-            </button>
-        </div>
-    </section>
     <section id="home">
     <div class="container mx-auto max-w-4xl p-4 sm:p-6">
         


### PR DESCRIPTION
## Summary
- Start app directly after selecting difficulty, saving settings and moving to the home view.
- Remove obsolete setup screen markup and related install/continue button handlers.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9a780187c832f87336d98fd20c5eb