### PR TITLE
Add reset confirmation modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -1686,12 +1686,12 @@ const closeExerciseModal = () => {
 };
 
 // --- Reset Confirmation Modal ---
-const openResetModal = () => {
-    document.getElementById('reset-modal').classList.remove('hidden');
+const openResetConfirm = () => {
+    document.getElementById('reset-confirm-modal').classList.remove('hidden');
 };
 
-const closeResetModal = () => {
-    document.getElementById('reset-modal').classList.add('hidden');
+const closeResetConfirm = () => {
+    document.getElementById('reset-confirm-modal').classList.add('hidden');
 };
 
 // --- PWA Install Prompt ---

--- a/index.html
+++ b/index.html
@@ -242,13 +242,13 @@
     </div>
 
     <!-- Reset Confirmation Modal -->
-    <div id="reset-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4 hidden scale-in">
+    <div id="reset-confirm-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4 hidden scale-in">
         <div class="modal-content bg-gray-900 border border-gray-700 rounded-lg max-w-md w-full p-4 sm:p-6 relative text-center">
             <h2 class="text-xl sm:text-2xl font-bold text-red-400 mb-4 font-display uppercase tracking-wider text-glow">Reset Progress?</h2>
             <p class="text-gray-400 mb-6">This will erase all progress. This action cannot be undone.</p>
             <div class="flex justify-center space-x-4">
-                <button onclick="resetProgram(); closeResetModal();" class="bg-red-600 hover:bg-red-700 text-black px-4 py-2 rounded font-bold clickable">Proceed</button>
-                <button onclick="closeResetModal()" class="bg-gray-700 hover:bg-gray-600 text-gray-300 px-4 py-2 rounded font-bold clickable">Cancel</button>
+                <button onclick="resetProgram(); closeResetConfirm();" class="bg-red-600 hover:bg-red-700 text-black px-4 py-2 rounded font-bold clickable">Proceed</button>
+                <button onclick="closeResetConfirm()" class="bg-gray-700 hover:bg-gray-600 text-gray-300 px-4 py-2 rounded font-bold clickable">Cancel</button>
             </div>
         </div>
     </div>
@@ -283,7 +283,7 @@
         <h2 class="text-xl font-display text-lime-400 mb-4">Settings</h2>
         <div class="space-y-4 max-w-sm mx-auto">
             <button onclick="openNotificationSettings()" class="w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Notifications</button>
-            <button onclick="resetProgram()" class="w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Change Difficulty / Program</button>
+            <button onclick="openResetConfirm()" class="w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Change Difficulty / Program</button>
             <a href="privacy.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Privacy Policy</a>
             <a href="terms.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Terms of Service</a>
             <a href="contact.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Contact</a>


### PR DESCRIPTION
## Summary
- add reset confirmation modal and hook up to settings
- implement modal controls so program reset only proceeds after user confirmation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9aa9023d8832f9fda6b483eb4f2c0