### PR TITLE
Expose reset modal functions globally

### DIFF
--- a/app.js
+++ b/app.js
@@ -1686,13 +1686,13 @@ const closeExerciseModal = () => {
 };
 
 // --- Reset Confirmation Modal ---
-const openResetConfirm = () => {
+function openResetConfirm() {
     document.getElementById('reset-confirm-modal').classList.remove('hidden');
-};
+}
 
-const closeResetConfirm = () => {
+function closeResetConfirm() {
     document.getElementById('reset-confirm-modal').classList.add('hidden');
-};
+}
 
 // --- PWA Install Prompt ---
 let deferredPrompt;


### PR DESCRIPTION
## Summary
- Use function declarations for `openResetConfirm` and `closeResetConfirm` so the reset confirmation modal can be opened from inline HTML handlers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- Manual Node check to ensure reset modal functions toggle the `hidden` class

------
https://chatgpt.com/codex/tasks/task_e_68b9af08087c832fb805fdc3b5da1e09