### PR TITLE
refactor: replace analytics modal with page

### DIFF
--- a/app.js
+++ b/app.js
@@ -1453,15 +1453,6 @@ function updateReminderTime(time) {
 
 
 // --- Chart Functions ---
-const openProgressModal = () => {
-    document.getElementById('progress-modal').classList.remove('hidden');
-    populateExerciseSelect();
-};
-
-const closeProgressModal = () => {
-    document.getElementById('progress-modal').classList.add('hidden');
-};
-
 const populateExerciseSelect = () => {
     const select = document.getElementById('chart-exercise-select');
     select.innerHTML = ''; // Clear old options
@@ -1866,6 +1857,10 @@ function switchView(viewId) {
       tab.removeAttribute('aria-current');
     }
   });
+
+  if (viewId === 'analytics') {
+    populateExerciseSelect();
+  }
 }
 
 // Initialize the app or onboarding when the page loads

--- a/index.html
+++ b/index.html
@@ -154,28 +154,6 @@
         </div>
     </div>
 
-    <!-- Progress Chart Modal -->
-    <div id="progress-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4 hidden scale-in">
-        <div class="modal-content bg-gray-900 border border-gray-700 rounded-lg max-w-3xl w-full p-4 sm:p-6 relative">
-            <button onclick="closeProgressModal()" class="absolute top-4 right-4 text-gray-500 hover:text-white">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-            </button>
-            <h2 class="text-xl sm:text-2xl font-bold text-lime-400 mb-4 font-display uppercase tracking-wider text-glow">Performance Analytics</h2>
-            
-            <div class="mb-4">
-                <label for="chart-exercise-select" class="block text-sm font-medium text-gray-400 mb-2">Select Exercise to Track:</label>
-                <select id="chart-exercise-select" class="w-full bg-gray-800 border border-gray-600 text-white rounded-lg p-3 focus:border-lime-500 focus:ring-lime-500 text-base">
-                    <!-- Options will be populated by JS -->
-                </select>
-            </div>
-            
-            <div class="overflow-x-auto">
-                <canvas id="progress-chart"></canvas>
-            </div>
-        </div>
-    </div>
     
     <!-- Weekly Debrief Modal -->
     <div id="debrief-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4 hidden bounce-in">
@@ -275,8 +253,18 @@
     </section>
 
     <section id="analytics" class="hidden container mx-auto max-w-4xl p-4 sm:p-6">
-        <h2 class="text-xl font-display text-lime-400 mb-4">Analytics</h2>
-        <p class="text-gray-400">Analytics content coming soon.</p>
+        <h2 class="text-xl sm:text-2xl font-bold text-lime-400 mb-4 font-display uppercase tracking-wider text-glow">Performance Analytics</h2>
+
+        <div class="mb-4">
+            <label for="chart-exercise-select" class="block text-sm font-medium text-gray-400 mb-2">Select Exercise to Track:</label>
+            <select id="chart-exercise-select" class="w-full bg-gray-800 border border-gray-600 text-white rounded-lg p-3 focus:border-lime-500 focus:ring-lime-500 text-base">
+                <!-- Options will be populated by JS -->
+            </select>
+        </div>
+
+        <div class="overflow-x-auto">
+            <canvas id="progress-chart"></canvas>
+        </div>
     </section>
 
     <section id="settings" class="hidden container mx-auto max-w-4xl p-4 sm:p-6">
@@ -295,7 +283,7 @@
             <img src="icons/home.svg" alt="" class="w-6 h-6" aria-hidden="true" />
             <span class="text-xs">Home</span>
         </button>
-        <button id="tab-analytics" data-view="analytics" onclick="switchView('analytics'); openProgressModal();" class="flex flex-col items-center text-gray-400 hover:text-lime-400" aria-label="Analytics">
+        <button id="tab-analytics" data-view="analytics" onclick="switchView('analytics')" class="flex flex-col items-center text-gray-400 hover:text-lime-400" aria-label="Analytics">
             <img src="icons/analytics.svg" alt="" class="w-6 h-6" aria-hidden="true" />
             <span class="text-xs">Analytics</span>
         </button>


### PR DESCRIPTION
## Summary
- Convert Performance Analytics from modal to dedicated analytics view
- Initialize analytics charts when the Analytics tab is selected

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9b5f8a2b0832fa732d1df264924c0