### PR TITLE
refactor: move reset to dedicated settings page

### DIFF
--- a/app.js
+++ b/app.js
@@ -610,19 +610,6 @@ const selectWeightUnit = (unit) => {
     renderProgram();
 };
 
-const resetProgram = () => {
-    localStorage.removeItem('hybridGoal');
-    localStorage.removeItem('hybridDifficulty');
-    localStorage.removeItem(`hybridData_${currentGoal}_${currentDifficulty}`);
-    completionStatus = {};
-    workoutDetails = {};
-    openWeeks = new Set();
-    openTools = new Set();
-    currentGoal = null;
-    currentDifficulty = null;
-    initializeApp();
-};
-
 const updateOverallProgress = () => {
     if (!currentDifficulty) return;
     const totalDays = currentProgramData.reduce((acc, phase) => acc + phase.weeks.reduce((wAcc, week) => wAcc + week.days.length, 0), 0);
@@ -1697,15 +1684,6 @@ const openExerciseModal = (exerciseName) => {
 const closeExerciseModal = () => {
     document.getElementById('exercise-modal').classList.add('hidden');
 };
-
-// --- Reset Confirmation Modal ---
-function openResetConfirm() {
-    document.getElementById('reset-confirm-modal').classList.remove('hidden');
-}
-
-function closeResetConfirm() {
-    document.getElementById('reset-confirm-modal').classList.add('hidden');
-}
 
 // --- PWA Install Prompt ---
 let deferredPrompt;

--- a/change-program.html
+++ b/change-program.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Change Program - HYBRID OPS</title>
+  <style>
+    body {
+      font-family: 'Roboto Mono', monospace;
+      line-height: 1.6;
+      margin: 2rem;
+      color: #D1D5DB;
+      max-width: 800px;
+      background-color: #000000;
+      background-image:
+          linear-gradient(45deg, rgba(255, 255, 255, 0.03) 25%, transparent 25%, transparent 75%, rgba(255, 255, 255, 0.03) 75%, rgba(255, 255, 255, 0.03)),
+          linear-gradient(-45deg, rgba(255, 255, 255, 0.03) 25%, transparent 25%, transparent 75%, rgba(255, 255, 255, 0.03) 75%, rgba(255, 255, 255, 0.03));
+      background-size: 6px 6px;
+    }
+    h1 {
+      margin-top: 1.5rem;
+      color: #A3E635;
+      font-family: 'Changa', sans-serif;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      text-shadow: 0 0 8px rgba(163, 230, 53, 0.7);
+    }
+    p {
+      margin-top: 1rem;
+    }
+    a {
+      color: #A3E635;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+      color: #84CC16;
+    }
+    .back-link {
+      display: inline-block;
+      margin-bottom: 2rem;
+      padding: 0.5rem 1rem;
+      background: transparent;
+      border: 2px solid #A3E635;
+      color: #A3E635;
+      text-decoration: none;
+      border-radius: 0.5rem;
+      transition: all 0.3s ease;
+      font-family: 'Changa', sans-serif;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+    }
+    .back-link:hover {
+      background: #A3E635;
+      color: #000000;
+      text-decoration: none;
+    }
+    .reset-button {
+      display: inline-block;
+      margin-top: 2rem;
+      padding: 0.75rem 1.5rem;
+      background: #DC2626;
+      color: #000000;
+      border: none;
+      border-radius: 0.5rem;
+      font-family: 'Changa', sans-serif;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      cursor: pointer;
+      transition: background 0.3s ease;
+    }
+    .reset-button:hover {
+      background: #EF4444;
+    }
+  </style>
+</head>
+<body>
+  <a href="index.html" class="back-link">&larr; Back</a>
+  <h1>Change Difficulty / Program</h1>
+  <p>Reset your progress to choose a different program or difficulty. This will erase all current progress and cannot be undone.</p>
+  <button id="reset-button" class="reset-button">Reset Program</button>
+  <script>
+    document.getElementById('reset-button').addEventListener('click', () => {
+      localStorage.removeItem('hybridGoal');
+      localStorage.removeItem('hybridDifficulty');
+      Object.keys(localStorage).forEach(key => {
+        if (key.startsWith('hybridData_')) {
+          localStorage.removeItem(key);
+        }
+      });
+      window.location.href = 'index.html';
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -219,17 +219,6 @@
         </div>
     </div>
 
-    <!-- Reset Confirmation Modal -->
-    <div id="reset-confirm-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4 hidden scale-in">
-        <div class="modal-content bg-gray-900 border border-gray-700 rounded-lg max-w-md w-full p-4 sm:p-6 relative text-center">
-            <h2 class="text-xl sm:text-2xl font-bold text-red-400 mb-4 font-display uppercase tracking-wider text-glow">Reset Progress?</h2>
-            <p class="text-gray-400 mb-6">This will erase all progress. This action cannot be undone.</p>
-            <div class="flex justify-center space-x-4">
-                <button onclick="resetProgram(); closeResetConfirm();" class="bg-red-600 hover:bg-red-700 text-black px-4 py-2 rounded font-bold clickable">Proceed</button>
-                <button onclick="closeResetConfirm()" class="bg-gray-700 hover:bg-gray-600 text-gray-300 px-4 py-2 rounded font-bold clickable">Cancel</button>
-            </div>
-        </div>
-    </div>
 
     <!-- Onboarding Walkthrough Modal -->
     <div id="onboarding-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4 hidden z-50">
@@ -271,7 +260,7 @@
         <h2 class="text-xl font-display text-lime-400 mb-4">Settings</h2>
         <div class="space-y-4 max-w-sm mx-auto">
             <button onclick="openNotificationSettings()" class="w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Notifications</button>
-            <button onclick="openResetConfirm()" class="w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Change Difficulty / Program</button>
+            <a href="change-program.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Change Difficulty / Program</a>
             <a href="privacy.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Privacy Policy</a>
             <a href="terms.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Terms of Service</a>
             <a href="contact.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Contact</a>


### PR DESCRIPTION
## Summary
- remove reset progress modal from main page
- add dedicated change-program page linked from settings
- drop unused reset modal scripts

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb47dfc8832f95243c04674e3139