### PR TITLE
Add weekly analytics charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,6 +256,18 @@
             <div class="overflow-x-auto">
                 <canvas id="progress-chart"></canvas>
             </div>
+
+            <div class="overflow-x-auto mt-8">
+                <canvas id="workouts-chart"></canvas>
+            </div>
+
+            <div class="overflow-x-auto mt-8">
+                <canvas id="volume-chart"></canvas>
+            </div>
+
+            <div class="overflow-x-auto mt-8">
+                <canvas id="distance-chart"></canvas>
+            </div>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Add workouts, volume, and distance canvases to analytics section
- Compute weekly totals from completion data and render bar, line, and pie charts with Chart.js
- Initialize weekly charts when navigating to analytics view

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c0160110832f9398a6367ea3eb4f