### PR TITLE
Add analytics time filter for week/overall views

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,6 +253,14 @@
                 </select>
             </div>
 
+            <div class="mb-4">
+                <label for="analytics-time-filter" class="block text-sm font-medium text-gray-400 mb-2">Timeframe:</label>
+                <select id="analytics-time-filter" class="w-full bg-gray-800 border border-gray-600 text-white rounded-lg p-3 focus:border-lime-500 focus:ring-lime-500 text-base">
+                    <option value="overall">Overall</option>
+                    <option value="week">This Week</option>
+                </select>
+            </div>
+
             <div class="overflow-x-auto">
                 <canvas id="progress-chart"></canvas>
             </div>


### PR DESCRIPTION
## Summary
- Add timeframe dropdown so analytics can switch between overall stats and current week metrics
- Filter workout data by selected timeframe when rendering charts and weekly totals
- Re-render analytics when the timeframe changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9c13f2f64832f80bd2ba9ab4992ca