### PR TITLE
Add weekly delta annotations to analytics charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,14 +267,17 @@
 
             <div class="overflow-x-auto mt-8">
                 <canvas id="workouts-chart"></canvas>
+                <p id="workouts-delta" class="text-gray-400 text-sm mt-1"></p>
             </div>
 
             <div class="overflow-x-auto mt-8">
                 <canvas id="volume-chart"></canvas>
+                <p id="volume-delta" class="text-gray-400 text-sm mt-1"></p>
             </div>
 
             <div class="overflow-x-auto mt-8">
                 <canvas id="distance-chart"></canvas>
+                <p id="distance-delta" class="text-gray-400 text-sm mt-1"></p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- aggregate weekly totals for workouts, volume, and distance across all weeks
- compute deltas vs previous week when rendering analytics charts
- show small text indicators beside charts with week-over-week comparisons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9c2825fe0832fa0602a0f3284851e