### PR TITLE
Add standalone notifications settings page

### DIFF
--- a/app.js
+++ b/app.js
@@ -1355,15 +1355,6 @@ function triggerNotificationPermission() {
     }
 }
 
-function openNotificationSettings() {
-    document.getElementById('notification-modal').classList.remove('hidden');
-    updateNotificationSettingsDisplay();
-}
-
-function closeNotificationSettings() {
-    document.getElementById('notification-modal').classList.add('hidden');
-}
-
 function updateNotificationSettingsDisplay() {
     const settings = getNotificationSettings();
     const container = document.getElementById('notification-settings');
@@ -2059,6 +2050,8 @@ function switchView(viewId) {
 
 // Initialize the app or onboarding when the page loads
 document.addEventListener('DOMContentLoaded', () => {
+  if (!document.getElementById('bottom-nav')) return;
+
   if (localStorage.getItem('hasSeenOnboarding') === 'true') {
     initializeApp();
     checkIosInstallPrompt();

--- a/index.html
+++ b/index.html
@@ -198,28 +198,6 @@
         </div>
     </div>
     
-    <!-- Notification Settings Modal -->
-    <div id="notification-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4 hidden scale-in">
-        <div class="modal-content bg-gray-900 border border-gray-700 rounded-lg max-w-md w-full p-4 sm:p-6 relative">
-            <button onclick="closeNotificationSettings()" class="absolute top-4 right-4 text-gray-500 hover:text-white">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-            </button>
-            <h2 class="text-xl sm:text-2xl font-bold text-lime-400 mb-4 font-display uppercase tracking-wider text-glow">Notification Settings</h2>
-            
-            <div id="notification-settings">
-                <!-- Content will be populated by JS -->
-            </div>
-            
-            <div class="mt-6 p-3 sm:p-4 bg-gray-800/50 rounded-lg">
-                <p class="text-xs text-gray-400 mb-2">📱 <strong>Mobile Tip:</strong></p>
-                <p class="text-xs text-gray-400">For best results, add HYBRID OPS to your home screen and enable notifications in your device settings.</p>
-            </div>
-        </div>
-    </div>
-
-
     <!-- Onboarding Walkthrough Modal -->
     <div id="onboarding-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4 hidden z-50">
         <div class="modal-content bg-gray-900 border border-gray-700 rounded-lg max-w-md w-full p-6 relative" role="dialog" aria-modal="true">
@@ -285,7 +263,7 @@
     <section id="settings" class="hidden container mx-auto max-w-4xl p-4 sm:p-6">
         <h2 class="text-xl font-display text-lime-400 mb-4">Settings</h2>
         <div class="space-y-4 max-w-sm mx-auto">
-            <button onclick="openNotificationSettings()" class="w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Notifications</button>
+            <a href="notifications.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Notifications</a>
             <a href="change-program.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Change Difficulty / Program</a>
             <a href="privacy.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Privacy Policy</a>
             <a href="terms.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Terms of Service</a>

--- a/notifications.html
+++ b/notifications.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Notification Settings - HYBRID OPS</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Changa:wght@600;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="bg-black text-gray-300 antialiased">
+  <div class="max-w-md mx-auto p-4">
+    <a href="index.html" class="text-lime-400 hover:text-lime-300">&larr; Back</a>
+    <h1 class="text-2xl font-bold text-lime-400 mt-4 mb-6 font-display uppercase tracking-wider text-glow">Notification Settings</h1>
+
+    <div id="notification-settings"></div>
+
+    <div class="mt-6 p-4 bg-gray-800/50 rounded-lg">
+      <p class="text-xs text-gray-400 mb-2">📱 <strong>Mobile Tip:</strong></p>
+      <p class="text-xs text-gray-400">For best results, add HYBRID OPS to your home screen and enable notifications in your device settings.</p>
+    </div>
+  </div>
+
+  <script src="app.js"></script>
+  <script>
+    updateNotificationSettingsDisplay();
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- replace notification modal with link to a new `notifications.html` page
- add dedicated notification settings page using existing toggle UI
- guard app initialization for pages without the main navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9c43c8d6c832f8595f8fcfff653ae