### PR TITLE
Expand notification settings and unify back links

### DIFF
--- a/app.js
+++ b/app.js
@@ -1319,7 +1319,9 @@ function getNotificationSettings() {
         workoutReminders: true,
         completionCelebrations: true,
         weeklyProgress: true,
-        reminderTime: '09:00'
+        motivationalMessages: true,
+        reminderTime: '09:00',
+        notificationType: 'push'
     };
 }
 
@@ -1367,33 +1369,49 @@ function updateNotificationSettingsDisplay() {
                     <div class="w-4 h-4 bg-white rounded-full absolute top-0.5 transition-transform ${settings.enabled ? 'translate-x-5' : 'translate-x-0.5'}"></div>
                 </button>
             </div>
-            
+
             ${settings.enabled ? `
                 <div class="space-y-3 pl-4 border-l-2 border-lime-500">
                     <div class="flex items-center justify-between py-1">
                         <label class="text-gray-300 text-sm">Workout Reminders</label>
-                        <button onclick="toggleNotificationType('workoutReminders')" class="w-10 h-5 rounded-full transition-colors ${settings.workoutReminders ? 'bg-lime-500' : 'bg-gray-600'} relative">
+                        <button onclick="toggleNotificationSetting('workoutReminders')" class="w-10 h-5 rounded-full transition-colors ${settings.workoutReminders ? 'bg-lime-500' : 'bg-gray-600'} relative">
                             <div class="w-4 h-4 bg-white rounded-full absolute top-0.5 transition-transform ${settings.workoutReminders ? 'translate-x-5' : 'translate-x-0.5'}"></div>
                         </button>
                     </div>
 
                     <div class="flex items-center justify-between py-1">
                         <label class="text-gray-300 text-sm">Completion Celebrations</label>
-                        <button onclick="toggleNotificationType('completionCelebrations')" class="w-10 h-5 rounded-full transition-colors ${settings.completionCelebrations ? 'bg-lime-500' : 'bg-gray-600'} relative">
+                        <button onclick="toggleNotificationSetting('completionCelebrations')" class="w-10 h-5 rounded-full transition-colors ${settings.completionCelebrations ? 'bg-lime-500' : 'bg-gray-600'} relative">
                             <div class="w-4 h-4 bg-white rounded-full absolute top-0.5 transition-transform ${settings.completionCelebrations ? 'translate-x-5' : 'translate-x-0.5'}"></div>
                         </button>
                     </div>
 
                     <div class="flex items-center justify-between py-1">
                         <label class="text-gray-300 text-sm">Weekly Progress</label>
-                        <button onclick="toggleNotificationType('weeklyProgress')" class="w-10 h-5 rounded-full transition-colors ${settings.weeklyProgress ? 'bg-lime-500' : 'bg-gray-600'} relative">
+                        <button onclick="toggleNotificationSetting('weeklyProgress')" class="w-10 h-5 rounded-full transition-colors ${settings.weeklyProgress ? 'bg-lime-500' : 'bg-gray-600'} relative">
                             <div class="w-4 h-4 bg-white rounded-full absolute top-0.5 transition-transform ${settings.weeklyProgress ? 'translate-x-5' : 'translate-x-0.5'}"></div>
                         </button>
                     </div>
 
+                    <div class="flex items-center justify-between py-1">
+                        <label class="text-gray-300 text-sm">Motivational Messages</label>
+                        <button onclick="toggleNotificationSetting('motivationalMessages')" class="w-10 h-5 rounded-full transition-colors ${settings.motivationalMessages ? 'bg-lime-500' : 'bg-gray-600'} relative">
+                            <div class="w-4 h-4 bg-white rounded-full absolute top-0.5 transition-transform ${settings.motivationalMessages ? 'translate-x-5' : 'translate-x-0.5'}"></div>
+                        </button>
+                    </div>
+
                     <div class="py-1">
-                        <label class="text-gray-300 block mb-2 text-sm">Daily Reminder Time</label>
+                        <label class="text-gray-300 block mb-2 text-sm">Daily Notification Time</label>
                         <input type="time" value="${settings.reminderTime}" onchange="updateReminderTime(this.value)" class="bg-gray-800 border border-gray-600 text-white rounded p-2 w-full focus:border-lime-500">
+                    </div>
+
+                    <div class="py-1">
+                        <label class="text-gray-300 block mb-2 text-sm">Notification Type</label>
+                        <select onchange="updateNotificationType(this.value)" class="bg-gray-800 border border-gray-600 text-white rounded p-2 w-full focus:border-lime-500">
+                            <option value="push" ${settings.notificationType === 'push' ? 'selected' : ''}>Push</option>
+                            <option value="email" ${settings.notificationType === 'email' ? 'selected' : ''}>Email</option>
+                            <option value="sms" ${settings.notificationType === 'sms' ? 'selected' : ''}>SMS</option>
+                        </select>
                     </div>
                 </div>
             ` : ''}
@@ -1418,7 +1436,7 @@ function toggleNotifications() {
     }
 }
 
-function toggleNotificationType(type) {
+function toggleNotificationSetting(type) {
     const settings = getNotificationSettings();
     settings[type] = !settings[type];
     saveNotificationSettings(settings);
@@ -1428,6 +1446,13 @@ function toggleNotificationType(type) {
 function updateReminderTime(time) {
     const settings = getNotificationSettings();
     settings.reminderTime = time;
+    saveNotificationSettings(settings);
+    updateNotificationSettingsDisplay();
+}
+
+function updateNotificationType(type) {
+    const settings = getNotificationSettings();
+    settings.notificationType = type;
     saveNotificationSettings(settings);
     updateNotificationSettingsDisplay();
 }

--- a/change-program.html
+++ b/change-program.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Change Program - HYBRID OPS</title>
+  <link rel="stylesheet" href="styles.css">
   <style>
     body {
       font-family: 'Roboto Mono', monospace;
@@ -35,25 +36,6 @@
     a:hover {
       text-decoration: underline;
       color: #84CC16;
-    }
-    .back-link {
-      display: inline-block;
-      margin-bottom: 2rem;
-      padding: 0.5rem 1rem;
-      background: transparent;
-      border: 2px solid #A3E635;
-      color: #A3E635;
-      text-decoration: none;
-      border-radius: 0.5rem;
-      transition: all 0.3s ease;
-      font-family: 'Changa', sans-serif;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-    }
-    .back-link:hover {
-      background: #A3E635;
-      color: #000000;
-      text-decoration: none;
     }
     .reset-button {
       display: inline-block;

--- a/contact.html
+++ b/contact.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Contact - HYBRID OPS</title>
+  <link rel="stylesheet" href="styles.css">
   <style>
     body {
       font-family: 'Roboto Mono', monospace;
@@ -34,25 +35,6 @@
     a:hover {
       text-decoration: underline;
       color: #84CC16;
-    }
-    .back-link {
-      display: inline-block;
-      margin-bottom: 2rem;
-      padding: 0.5rem 1rem;
-      background: transparent;
-      border: 2px solid #A3E635;
-      color: #A3E635;
-      text-decoration: none;
-      border-radius: 0.5rem;
-      transition: all 0.3s ease;
-      font-family: 'Changa', sans-serif;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-    }
-    .back-link:hover {
-      background: #A3E635;
-      color: #000000;
-      text-decoration: none;
     }
     .contact-info {
       background: rgba(55, 65, 81, 0.3);

--- a/notifications.html
+++ b/notifications.html
@@ -12,15 +12,10 @@
 </head>
 <body class="bg-black text-gray-300 antialiased">
   <div class="max-w-md mx-auto p-4">
-    <a href="index.html" class="text-lime-400 hover:text-lime-300">&larr; Back</a>
+    <a href="index.html" class="back-link">&larr; Back</a>
     <h1 class="text-2xl font-bold text-lime-400 mt-4 mb-6 font-display uppercase tracking-wider text-glow">Notification Settings</h1>
 
     <div id="notification-settings"></div>
-
-    <div class="mt-6 p-4 bg-gray-800/50 rounded-lg">
-      <p class="text-xs text-gray-400 mb-2">📱 <strong>Mobile Tip:</strong></p>
-      <p class="text-xs text-gray-400">For best results, add HYBRID OPS to your home screen and enable notifications in your device settings.</p>
-    </div>
   </div>
 
   <script src="app.js"></script>

--- a/privacy.html
+++ b/privacy.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Privacy Policy - HYBRID OPS</title>
+  <link rel="stylesheet" href="styles.css">
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -11,6 +12,7 @@
       margin: 2rem;
       color: #222;
       max-width: 800px;
+      background-color: #ffffff;
     }
     h1, h2 {
       margin-top: 1.5rem;
@@ -22,25 +24,6 @@
     }
     a:hover {
       text-decoration: underline;
-    }
-    .back-link {
-      display: inline-block;
-      margin-bottom: 2rem;
-      padding: 0.5rem 1rem;
-      background: transparent;
-      border: 2px solid #A3E635;
-      color: #A3E635;
-      text-decoration: none;
-      border-radius: 0.5rem;
-      transition: all 0.3s ease;
-      font-family: 'Changa', sans-serif;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-    }
-    .back-link:hover {
-      background: #A3E635;
-      color: #000000;
-      text-decoration: none;
     }
   </style>
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/styles.css
+++ b/styles.css
@@ -38,8 +38,30 @@ body {
     box-shadow: 0 0 8px #A3E635, 0 0 16px #A3E635; 
 }
 
-.text-glow { 
-    text-shadow: 0 0 8px rgba(163, 230, 53, 0.7); 
+.text-glow {
+    text-shadow: 0 0 8px rgba(163, 230, 53, 0.7);
+}
+
+/* Uniform back link styling */
+.back-link {
+    display: inline-block;
+    margin-bottom: 2rem;
+    padding: 0.5rem 1rem;
+    background: transparent;
+    border: 2px solid #A3E635;
+    color: #A3E635;
+    text-decoration: none;
+    border-radius: 0.5rem;
+    transition: all 0.3s ease;
+    font-family: 'Changa', sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.back-link:hover {
+    background: #A3E635;
+    color: #000000;
+    text-decoration: none;
 }
 
 /* Loading States */

--- a/terms.html
+++ b/terms.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Terms of Service - HYBRID OPS</title>
+  <link rel="stylesheet" href="styles.css">
   <style>
     body {
       font-family: 'Roboto Mono', monospace;
@@ -39,25 +40,6 @@
       border: none;
       border-top: 2px solid #374151;
       margin: 2rem 0;
-    }
-    .back-link {
-      display: inline-block;
-      margin-bottom: 2rem;
-      padding: 0.5rem 1rem;
-      background: transparent;
-      border: 2px solid #A3E635;
-      color: #A3E635;
-      text-decoration: none;
-      border-radius: 0.5rem;
-      transition: all 0.3s ease;
-      font-family: 'Changa', sans-serif;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-    }
-    .back-link:hover {
-      background: #A3E635;
-      color: #000000;
-      text-decoration: none;
     }
   </style>
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- Add motivational messages toggle, notification type selector, and daily time option to notification settings
- Remove mobile tip and standardize back links across settings pages using shared CSS

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9c7e90de0832f89f3ccd7c3df6b54