### PR TITLE
Add PWA install prompt and settings entry

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,36 @@ if ('serviceWorker' in navigator) {
         .catch(e => console.log('ServiceWorker registration failed:', e));
 }
 
+let deferredPrompt;
+
+window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault();
+    deferredPrompt = e;
+    const btn = document.getElementById('install-app-btn');
+    const instructions = document.getElementById('install-instructions');
+    if (btn) btn.classList.remove('hidden');
+    if (instructions) instructions.classList.add('hidden');
+});
+
+function triggerInstallPrompt() {
+    if (!deferredPrompt) {
+        const btn = document.getElementById('install-app-btn');
+        const instructions = document.getElementById('install-instructions');
+        if (btn) btn.classList.add('hidden');
+        if (instructions) instructions.classList.remove('hidden');
+        return;
+    }
+    deferredPrompt.prompt();
+    deferredPrompt.userChoice.then((choice) => {
+        console.log(`User choice: ${choice.outcome}`);
+        const btn = document.getElementById('install-app-btn');
+        const instructions = document.getElementById('install-instructions');
+        if (btn) btn.classList.add('hidden');
+        if (choice.outcome === 'dismissed' && instructions) instructions.classList.remove('hidden');
+        deferredPrompt = null;
+    });
+}
+
 const icons = {
     strength: `<svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor"><path d="M20.5,3A3.5,3.5,0,0,0,17,6.5V17.5A3.5,3.5,0,0,0,20.5,21A3.5,3.5,0,0,0,24,17.5V6.5A3.5,3.5,0,0,0,20.5,3M3.5,3A3.5,3.5,0,0,0,0,6.5V17.5A3.5,3.5,0,0,0,3.5,21A3.5,3.5,0,0,0,7,17.5V6.5A3.5,3.5,0,0,0,3.5,3M9,5H15V19H9V5Z" /></svg>`,
     run: `<svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor"><path d="M13.49 5.48c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm-3.6 13.9l1-4.4 2.1 2v6h2v-7.5l-2.1-2 .6-3c1.3 1.5 3.3 2.5 5.5 2.5v-2c-1.9 0-3.5-1-4.3-2.4l-1-1.6c-.4-.6-1-1-1.7-1-.3 0-.5.1-.8.1l-5.2 2.2v4.7h2v-3.4l1.8-.7-1.6 8.1-4.9-1-.4 2 7 1.4z"/></svg>`,

--- a/index.html
+++ b/index.html
@@ -267,6 +267,8 @@
             <a href="privacy.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Privacy Policy</a>
             <a href="terms.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Terms of Service</a>
             <a href="contact.html" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable">Contact</a>
+            <button id="install-app-btn" onclick="triggerInstallPrompt()" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg hover:bg-lime-500/20 hover:border-lime-500 clickable hidden">Install App</button>
+            <p id="install-instructions" class="block w-full text-left p-4 bg-gray-800/50 border border-gray-700 rounded-lg text-gray-400 text-sm">To install this app, open your browser menu and select "Add to Home screen".</p>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- add beforeinstallprompt handler in app.js to manage deferred install prompt
- expose triggerInstallPrompt function and manual-install fallback
- include Install App entry in Settings with instruction text

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9e0f15e5c832f9a5084b12df5868c