### PR TITLE
Add beta badge to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         <div id="welcome-screen" class="text-center flex flex-col justify-center fade-in" style="min-height: calc(100vh - 3rem);">
             <div>
                  <div class="pt-10">
-                    <h3 class="font-display text-lime-400 text-3xl sm:text-4xl md:text-5xl lg:text-6xl uppercase text-glow" style="letter-spacing: 0.1em; word-break: break-word;">[HYBRID OPS]</h3>
+                    <h3 class="font-display text-lime-400 text-3xl sm:text-4xl md:text-5xl lg:text-6xl uppercase text-glow" style="letter-spacing: 0.1em; word-break: break-word;">[HYBRID OPS]<span class="beta-badge">BETA</span></h3>
                     <div class="flex flex-wrap justify-center items-center space-x-2 sm:space-x-4 mt-6 text-gray-200 font-bold tracking-widest text-xs sm:text-sm max-w-md mx-auto">
                         <p class="pillar" style="animation-delay: 0.2s;">[STRENGTH]</p>
                         <p class="pillar-separator text-lime-400">-</p>

--- a/styles.css
+++ b/styles.css
@@ -42,6 +42,16 @@ body {
     text-shadow: 0 0 8px rgba(163, 230, 53, 0.7);
 }
 
+/* Reusable badge styling for beta labels */
+.beta-badge {
+    margin-left: 0.5rem; /* ml-2 */
+    padding: 0.25rem 0.5rem; /* py-1 px-2 */
+    font-size: 0.75rem; /* text-xs */
+    background-color: #84CC16; /* bg-lime-500 */
+    color: #000000; /* text-black */
+    border-radius: 0.25rem; /* rounded */
+}
+
 /* Uniform back link styling */
 .back-link {
     display: inline-block;


### PR DESCRIPTION
## Summary
- Display a **BETA** badge beside the HYBRID OPS heading on the landing page.
- Introduce reusable `.beta-badge` CSS class for consistent badge styling.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9e94eb00c832fb6b9ea7c573d5daf