### PR TITLE
Refactor timer utilities and add Jest tests

### DIFF
--- a/__tests__/timer.test.js
+++ b/__tests__/timer.test.js
@@ -1,0 +1,58 @@
+import {
+  formatTime,
+  createTimerState,
+  startTimer,
+  stopTimer,
+  resetTimer,
+  setCountdownTime,
+} from '../src/utils/timer.js';
+
+describe('timer utilities', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('formatTime formats seconds into mm:ss', () => {
+    expect(formatTime(0)).toBe('00:00');
+    expect(formatTime(65)).toBe('01:05');
+  });
+
+  test('startTimer increments stopwatch', () => {
+    const state = createTimerState(0, true);
+    const interval = startTimer(state);
+    jest.advanceTimersByTime(3000);
+    expect(state.time).toBe(3);
+    stopTimer(state, interval);
+  });
+
+  test('countdown timer decrements and stops at zero', () => {
+    const state = createTimerState(5, false);
+    const onComplete = jest.fn();
+    const interval = startTimer(state, undefined, onComplete);
+    jest.advanceTimersByTime(6000);
+    expect(state.time).toBe(0);
+    expect(onComplete).toHaveBeenCalled();
+    stopTimer(state, interval);
+  });
+
+  test('resetTimer resets based on mode', () => {
+    const state = createTimerState(10, true);
+    const interval = startTimer(state);
+    jest.advanceTimersByTime(3000);
+    resetTimer(state, true);
+    expect(state.time).toBe(0);
+    stopTimer(state, interval);
+
+    const countdown = createTimerState();
+    setCountdownTime(countdown, 1);
+    const int2 = startTimer(countdown);
+    jest.advanceTimersByTime(3000);
+    resetTimer(countdown, false);
+    expect(countdown.time).toBe(60);
+    stopTimer(countdown, int2);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -293,6 +293,6 @@
         <span id="workout-complete-text"></span>
     </div>
 
-    <script src="app.js"></script>
+    <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'jsdom'
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "http-server . -p 3000 -c-1",
     "build": "echo 'Static files ready'",
-    "preview": "http-server . -p 4173 -c-1"
+    "preview": "http-server . -p 4173 -c-1",
+    "test": "jest"
   },
   "keywords": [
     "fitness",

--- a/src/utils/timer.js
+++ b/src/utils/timer.js
@@ -1,0 +1,46 @@
+export const formatTime = (time) => {
+  const minutes = Math.floor(time / 60).toString().padStart(2, '0');
+  const seconds = (time % 60).toString().padStart(2, '0');
+  return `${minutes}:${seconds}`;
+};
+
+export const createTimerState = (time = 0, isStopwatch = true) => ({
+  time,
+  running: false,
+  isStopwatch,
+  initialTime: time,
+});
+
+export const startTimer = (timerState, onTick, onComplete) => {
+  timerState.running = true;
+  const interval = setInterval(() => {
+    if (timerState.isStopwatch) {
+      timerState.time++;
+    } else if (timerState.time > 0) {
+      timerState.time--;
+      if (timerState.time === 0 && onComplete) {
+        onComplete();
+      }
+    } else if (onComplete) {
+      onComplete();
+    }
+    if (onTick) onTick(timerState.time);
+  }, 1000);
+  return interval;
+};
+
+export const stopTimer = (timerState, interval) => {
+  clearInterval(interval);
+  timerState.running = false;
+};
+
+export const resetTimer = (timerState, isStopwatch = timerState.isStopwatch) => {
+  timerState.time = isStopwatch ? 0 : timerState.initialTime;
+  timerState.running = false;
+};
+
+export const setCountdownTime = (timerState, minutes) => {
+  timerState.time = minutes * 60;
+  timerState.initialTime = timerState.time;
+  timerState.isStopwatch = false;
+};


### PR DESCRIPTION
## Summary
- extract timer helpers into `src/utils/timer.js`
- expose timer functionality via ES module imports
- add Jest config and timer tests

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ed3ebb4c832f91432b8f35541616