### PR TITLE
Float standalone beta badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,13 +24,14 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body class="text-gray-300 antialiased">
+    <div class="beta-badge">BETA</div>
     <section id="home">
     <div class="container mx-auto max-w-4xl p-4 sm:p-6">
         
         <div id="welcome-screen" class="text-center flex flex-col justify-center fade-in" style="min-height: calc(100vh - 3rem);">
             <div>
                  <div class="pt-10">
-                    <h3 class="font-display text-lime-400 text-3xl sm:text-4xl md:text-5xl lg:text-6xl uppercase text-glow" style="letter-spacing: 0.1em; word-break: break-word;">[HYBRID OPS]<span class="beta-badge">BETA</span></h3>
+                    <h3 class="font-display text-lime-400 text-3xl sm:text-4xl md:text-5xl lg:text-6xl uppercase text-glow" style="letter-spacing: 0.1em; word-break: break-word;">[HYBRID OPS]</h3>
                     <div class="flex flex-wrap justify-center items-center space-x-2 sm:space-x-4 mt-6 text-gray-200 font-bold tracking-widest text-xs sm:text-sm max-w-md mx-auto">
                         <p class="pillar" style="animation-delay: 0.2s;">[STRENGTH]</p>
                         <p class="pillar-separator text-lime-400">-</p>

--- a/styles.css
+++ b/styles.css
@@ -44,7 +44,11 @@ body {
 
 /* Reusable badge styling for beta labels */
 .beta-badge {
-    margin-left: 0.5rem; /* ml-2 */
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    margin-left: 0;
+    z-index: 1000;
     padding: 0.25rem 0.5rem; /* py-1 px-2 */
     font-size: 0.75rem; /* text-xs */
     background-color: #84CC16; /* bg-lime-500 */


### PR DESCRIPTION
## Summary
- Move beta badge out of hero heading and render independently
- Fix beta badge styling to pin at top-right

## Testing
- `npm test` *(fails: jest not found)*
- `npx --yes jest` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f1159dc8832f8de8755c0e608da8