### PR TITLE
Initialize app before onboarding and add element checks

### DIFF
--- a/app.js
+++ b/app.js
@@ -1854,13 +1854,17 @@ function startOnboarding() {
   showOnboardingStep();
 }
 
-onboardingNext.addEventListener('click', () => {
-  finishOnboarding();
-});
+if (onboardingNext) {
+  onboardingNext.addEventListener('click', () => {
+    finishOnboarding();
+  });
+}
 
-onboardingSkip.addEventListener('click', () => {
-  finishOnboarding();
-});
+if (onboardingSkip) {
+  onboardingSkip.addEventListener('click', () => {
+    finishOnboarding();
+  });
+}
 
 // Switch between main views
 function switchView(viewId) {
@@ -1894,11 +1898,12 @@ function switchView(viewId) {
 document.addEventListener('DOMContentLoaded', () => {
   if (!document.getElementById('bottom-nav')) return;
 
-  if (localStorage.getItem('hasSeenOnboarding') === 'true') {
-    initializeApp();
-    checkIosInstallPrompt();
-  } else {
+  initializeApp();
+
+  if (localStorage.getItem('hasSeenOnboarding') !== 'true') {
     startOnboarding();
+  } else {
+    checkIosInstallPrompt();
   }
   switchView('home');
 


### PR DESCRIPTION
## Summary
- Initialize app before checking onboarding status to ensure welcome flow loads
- Start onboarding only if user hasn't seen it yet
- Guard onboarding event listeners to avoid missing element errors

## Testing
- `npm test` *(fails: jest not found and installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f29d0308832fb92a7667c018dc19