### PR TITLE
Fix welcome screen initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -1791,7 +1791,6 @@ window.closeExerciseModal = () => {
 };
 
 // --- PWA Install Prompt ---
-let deferredPrompt;
 const iosPrompt = document.getElementById('ios-pwa-prompt');
 const iosPromptDismiss = document.getElementById('ios-pwa-dismiss');
 


### PR DESCRIPTION
## Summary
- Remove duplicate `deferredPrompt` declaration that prevented JavaScript from running
- Ensure PWA install prompt setup uses single shared variable

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0b613884832fae63a6a52134f285