### PR TITLE
Refactor onboarding install prompt

### DIFF
--- a/app.js
+++ b/app.js
@@ -1816,50 +1816,42 @@ if (iosPromptDismiss) {
 }
 
 // --- Onboarding Walkthrough ---
-const onboardingModal = document.getElementById('onboarding-modal');
-const onboardingContent = document.getElementById('onboarding-content');
-const onboardingBack = document.getElementById('onboarding-back');
-const onboardingNext = document.getElementById('onboarding-next');
-const onboardingSkip = document.getElementById('onboarding-skip');
+function promptInstallAfterOnboarding() {
+  if (deferredPrompt) {
+    deferredPrompt.prompt();
+    deferredPrompt.userChoice.then((choice) => {
+      console.log(`User choice: ${choice.outcome}`);
+      if (choice.outcome === 'dismissed') {
+        const banner = document.getElementById('post-onboarding-install');
+        if (banner) banner.classList.remove('hidden');
+      }
+      deferredPrompt = null;
+    });
+  } else {
+    const banner = document.getElementById('post-onboarding-install');
+    if (banner) banner.classList.remove('hidden');
+  }
 
-function renderOnboardingInstall() {
-  const installAction = deferredPrompt ? '<button id="onboarding-install" class="btn-primary w-full p-3 mt-4 bg-lime-500 hover:bg-lime-600 text-black font-bold rounded">Install App</button>' : '<p class="text-sm text-gray-400 mt-4 text-center">Use your browser\'s menu to add this app to your home screen.</p>';
-  return `
-    <h2 class="text-xl font-bold text-lime-400 mb-4 font-display uppercase tracking-wider text-center">Add to Home Screen</h2>
-    <p class="text-sm text-gray-400 text-center">Install HYBRID OPS for a full-screen experience.</p>
-    ${installAction}
-  `;
-}
-
-function showOnboardingStep() {
-  onboardingBack.classList.add('hidden');
-  onboardingNext.textContent = 'Finish';
-  onboardingContent.innerHTML = renderOnboardingInstall();
-
-  const focusable = onboardingModal.querySelector('button');
-  if (focusable) focusable.focus();
+  const dismiss = document.getElementById('post-onboarding-install-dismiss');
+  if (dismiss) {
+    dismiss.addEventListener('click', () => {
+      const banner = document.getElementById('post-onboarding-install');
+      if (banner) banner.classList.add('hidden');
+    }, { once: true });
+  }
 }
 
 function finishOnboarding() {
-  onboardingModal.classList.add('hidden');
   localStorage.setItem('hasSeenOnboarding','true');
   initializeApp();
   switchView('home');
   checkIosInstallPrompt();
+  promptInstallAfterOnboarding();
 }
 
 function startOnboarding() {
-  onboardingModal.classList.remove('hidden');
-  showOnboardingStep();
+  finishOnboarding();
 }
-
-onboardingNext.addEventListener('click', () => {
-  finishOnboarding();
-});
-
-onboardingSkip.addEventListener('click', () => {
-  finishOnboarding();
-});
 
 // Switch between main views
 function switchView(viewId) {

--- a/index.html
+++ b/index.html
@@ -218,6 +218,12 @@
         <p class="text-sm mb-2">Tap <span class="font-bold">Share</span> → <span class="font-bold">Add to Home Screen</span></p>
         <button id="ios-pwa-dismiss" class="text-xs text-lime-400 hover:text-lime-300 underline">Dismiss</button>
     </div>
+
+    <!-- Post-onboarding install prompt -->
+    <div id="post-onboarding-install" class="fixed bottom-4 left-1/2 -translate-x-1/2 transform bg-gray-900 border border-lime-500 text-gray-200 p-4 rounded-lg shadow-lg text-center hidden z-50">
+        <p class="text-sm mb-2">To install this app, open your browser menu and select "Add to Home screen".</p>
+        <button id="post-onboarding-install-dismiss" class="text-xs text-lime-400 hover:text-lime-300 underline">Dismiss</button>
+    </div>
     </section>
 
     <section id="analytics" class="hidden container mx-auto max-w-4xl p-4 sm:p-6">


### PR DESCRIPTION
## Summary
- Remove install step from onboarding and move install prompt to post-onboarding flow
- Add banner container for install instructions on the home screen
- Prompt for app installation after onboarding finishes

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install --save-dev jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0f37e504832f809817e3028d6687