### PR TITLE
Expose switchView globally for navigation tabs

### DIFF
--- a/app.js
+++ b/app.js
@@ -1881,6 +1881,8 @@ function switchView(viewId) {
   }
 }
 
+window.switchView = switchView;
+
 // Initialize the app or onboarding when the page loads
 document.addEventListener('DOMContentLoaded', () => {
   if (!document.getElementById('bottom-nav')) return;


### PR DESCRIPTION
## Summary
- Make `switchView` available on the `window` object so inline navigation handlers can switch between Home, Analytics, and Settings views

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install --no-save jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2bf2634c832f8184e800e74b044e